### PR TITLE
[CLOUD-2029] bpmsuite: BC and controller images do not need activemq-rar

### DIFF
--- a/businesscentral-monitoring/image.yaml
+++ b/businesscentral-monitoring/image.yaml
@@ -264,8 +264,6 @@ sources:
       md5: 2f74acc3efc68e3781b7004f5a683fdc
     - artifact: oauth-20100527.jar
       md5: 91c7c70579f95b7ddee95b2143a49b41
-    - artifact: https://maven.repository.redhat.com/ga/org/apache/activemq/activemq-rar/5.11.0.redhat-630262/activemq-rar-5.11.0.redhat-630262.rar
-      md5: d0c70b9b2da1f02473d52f59d1d14b0b
     - artifact: hawkular-javaagent-1.0.0.CR5-redhat-1-shaded.jar
       md5: f5d3e0220e10c706ef86af84771cf74e
     - artifact: rh-sso-7.0.0-eap7-adapter.zip
@@ -302,9 +300,6 @@ cct:
                 - user: 185
                 - configure_sh:
           - cct_module.os-eap70-openshift:
-                - user: 185
-                - configure_sh:
-          - cct_module.os-eap-activemq-rar:
                 - user: 185
                 - configure_sh:
           - cct_module.os-java-run:

--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -264,8 +264,6 @@ sources:
       md5: 2f74acc3efc68e3781b7004f5a683fdc
     - artifact: oauth-20100527.jar
       md5: 91c7c70579f95b7ddee95b2143a49b41
-    - artifact: https://maven.repository.redhat.com/ga/org/apache/activemq/activemq-rar/5.11.0.redhat-630262/activemq-rar-5.11.0.redhat-630262.rar
-      md5: d0c70b9b2da1f02473d52f59d1d14b0b
     - artifact: hawkular-javaagent-1.0.0.CR5-redhat-1-shaded.jar
       md5: f5d3e0220e10c706ef86af84771cf74e
     - artifact: rh-sso-7.0.0-eap7-adapter.zip
@@ -302,9 +300,6 @@ cct:
                 - user: 185
                 - configure_sh:
           - cct_module.os-eap70-openshift:
-                - user: 185
-                - configure_sh:
-          - cct_module.os-eap-activemq-rar:
                 - user: 185
                 - configure_sh:
           - cct_module.os-java-run:

--- a/standalonecontroller/image.yaml
+++ b/standalonecontroller/image.yaml
@@ -207,8 +207,6 @@ sources:
       md5: 2f74acc3efc68e3781b7004f5a683fdc
     - artifact: oauth-20100527.jar
       md5: 91c7c70579f95b7ddee95b2143a49b41
-    - artifact: https://maven.repository.redhat.com/ga/org/apache/activemq/activemq-rar/5.11.0.redhat-630262/activemq-rar-5.11.0.redhat-630262.rar
-      md5: d0c70b9b2da1f02473d52f59d1d14b0b
     - artifact: hawkular-javaagent-1.0.0.CR5-redhat-1-shaded.jar
       md5: f5d3e0220e10c706ef86af84771cf74e
     - artifact: rh-sso-7.0.0-eap7-adapter.zip
@@ -245,9 +243,6 @@ cct:
                 - user: 185
                 - configure_sh:
           - cct_module.os-eap70-openshift:
-                - user: 185
-                - configure_sh:
-          - cct_module.os-eap-activemq-rar:
                 - user: 185
                 - configure_sh:
           - cct_module.os-java-run:


### PR DESCRIPTION
Those apps do not have any JMS support. It only brings maintenance pain.

Note: the JIRA is not yet approved.

@errantepiphany could you please take a look?